### PR TITLE
feat(kafka-broker): initial commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,34 @@ jobs:
       - run: yarn workspace << parameters.scope >>/<< parameters.package >> test
       - run: ./node_modules/.bin/codecov -f packages/<< parameters.package >>/coverage/clover.xml -F << parameters.package >>
 
+  test-with-kafka:
+    parameters:
+      scope:
+        type: string
+        default: '@vpriem'
+      package:
+        type: string
+
+    docker:
+      - image: cimg/node:12.20.1
+      - image: wurstmeister/zookeeper:latest
+      - image: wurstmeister/kafka:2.11-1.1.1
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+          KAFKA_DELETE_TOPIC_ENABLE: "true"
+
+    environment:
+      KAFKA_BROKER: localhost:9092
+
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: yarn workspace << parameters.scope >>/<< parameters.package >> test
+      - run: ./node_modules/.bin/codecov -f packages/<< parameters.package >>/coverage/clover.xml -F << parameters.package >>
+
   lint:
     parameters:
       scope:
@@ -82,12 +110,21 @@ workflows:
           name: lint-rest-client
           package: rest-client
 
+      - test-with-kafka:
+          name: test-kafka-broker
+          package: kafka-broker
+      - lint:
+          name: lint-kafka-broker
+          package: kafka-broker
+
       - build-and-publish:
           requires:
             - test-express-api-key-auth
             - lint-express-api-key-auth
-#            - test-rest-client
-#            - lint-rest-client
+            - test-rest-client
+            - lint-rest-client
+            - test-kafka-broker
+            - lint-kafka-broker
           filters:
             branches:
               only: master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.11-1.1.1
+    ports:
+      - "9092:9092"
+    links:
+      - zookeeper
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: ${HOST_IP:-192.168.0.10}
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "u": "yarn upgrade-interactive --latest",
     "w": "yarn workspace",
     "e": "yarn workspace @vpriem/express-api-key-auth",
-    "r": "yarn workspace @vpriem/rest-client"
+    "r": "yarn workspace @vpriem/rest-client",
+    "k": "yarn workspace @vpriem/kafka-broker"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",

--- a/packages/kafka-broker/.yarnrc
+++ b/packages/kafka-broker/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix: ''

--- a/packages/kafka-broker/README.md
+++ b/packages/kafka-broker/README.md
@@ -1,0 +1,289 @@
+# kafka-broker
+
+⚠️ UNDER DEVELOPMENT: The API might change in the future.
+
+A wrapper around [KafkaJS](https://www.npmjs.com/package/kafkajs).  
+Easily compose your broker and manage your Kafka resources
+into one place to keep the overview inside your event driven service.
+
+Heavily inspired from [Rascal](https://github.com/guidesmiths/rascal).
+
+#### Features:
+
+-   Global resource configuration
+-   Lazy resource creation
+-   Multiple brokers orchestration
+-   Topic name alias
+-   JSON encoding/decoding support
+-   Async/Await
+-   Type safe publishing/consuming
+-   Consume messages with Handlers or EventEmitter
+-   Global shutdown
+-   Strong integration/unit tests
+
+## Install
+
+```shell
+yarn add @vpriem/kafka-broker
+```
+
+## Usage
+
+### Configuration
+
+First configure the broker:
+
+```typescript
+import { Broker } from '@vpriem/kafka-broker';
+
+const broker = new Broker({
+    namespace: 'my-service',
+    config: {
+        brokers: [process.env.KAFKA_BROKER as string],
+    },
+    publications: {
+        'to-my-topic': 'my-long-topic-name',
+    },
+    subscriptions: {
+        'from-my-topic': 'my-long-topic-name',
+    },
+});
+```
+
+This will create a default producer and a default consumer with the groupId `my-service.from-my-topic`.  
+Connections will be first started once published to `to-my-topic`
+or the subscription `from-my-topic` is started.
+
+This is equivalent of doing:
+
+```typescript
+const broker = new Broker({
+    namespace: 'my-service',
+    config: {
+        clientId: 'my-service',
+        brokers: [process.env.KAFKA_BROKER as string],
+    },
+    producers: {
+        default: {},
+    },
+    publications: {
+        'to-my-topic': {
+            topic: 'my-long-topic-name',
+            producer: 'default',
+        },
+    },
+    subscriptions: {
+        'from-my-topic': {
+            topics: 'my-long-topic-name',
+            consumer: {
+                groupId: 'my-service.from-my-topic',
+            },
+        },
+    },
+});
+```
+
+### Publishing messages
+
+```typescript
+await broker.publish('to-my-topic', { value: 'my-message' });
+// Or mutilple messages:
+await broker.publish('to-my-topic', [
+    { value: 'my-message' },
+    { value: 'my-message' },
+]);
+```
+
+This will publish to `my-long-topic-name` using the `default` producer.
+
+### Consuming messages
+
+In order to consume messages you have to get the subscription and run it:
+
+```typescript
+import { ConsumeMessage } from '@vpriem/kafka-broker';
+
+await broker
+    .subscription('from-my-topic')
+    .on('message', ({ value }: ConsumeMessage) => {
+        console.log(value); // Print "my-message"
+    })
+    .run();
+```
+
+This will consume messages from `my-long-topic-name` using `my-service.from-my-topic` consumer group.
+
+### JSON support
+
+Published objects are automatically JSON encoded.  
+A `content-type: application/json"` header is also added to the message headers.
+
+```typescript
+await broker.publish('to-my-topic', { value: { id: 1 } });
+// Or type safe:
+await broker.publish<{ id: number }>('to-my-topic', { value: { id: 1 } });
+```
+
+Previously JSON encoded messages are decoded back using the previously set `content-type` header.
+
+```typescript
+await broker
+    .subscription('from-my-topic')
+    .on('message', ({ value }: ConsumeMessage<object>) => {
+        console.log(value.id); // Print 1
+    })
+    .run();
+
+// Or type safe:
+
+interface MyMessage {
+    id: number;
+}
+
+await broker
+    .subscription('from-my-topic')
+    .on('message', ({ value }: ConsumeMessage<MyMessage>) => {
+        console.log(value.id); // Print 1
+    })
+    .run();
+```
+
+### Handlers
+
+You can use `Handlers` to consume messages.
+
+```typescript
+const broker = new Broker({
+    // ...
+    subscriptions: {
+        'from-my-topic': {
+            topics: 'my-long-topic-name',
+            handler: async ({ value }) => {
+                await myAsyncOperation(value);
+            },
+        },
+    },
+});
+
+await broker.subscription('from-my-topic').run();
+```
+
+### Consuming from multiple topics
+
+You can subscribe to multiple topics inside the same subscription/consumer group.  
+And consume per topic messages with `.on('message.{topic|alias}')` or by defining handlers.
+
+```typescript
+const broker = new Broker({
+    // ...
+    publications: {
+        'to-my-topic-1': 'my-long-topic-name-1',
+        'to-my-topic-2': 'my-long-topic-name-2',
+    },
+    subscriptions: {
+        'from-all-topics': {
+            topics: [
+                {
+                    topic: 'my-long-topic-name-1',
+                    alias: 'my-topic-1',
+                    handler: async ({ value }) => {
+                        // This will be called with "value-1"
+                        await myAsyncOperation(value);
+                    },
+                },
+                {
+                    topic: 'my-long-topic-name-2',
+                    alias: 'my-topic-2',
+                    handler: async ({ value }) => {
+                        // This will be called with "value-2"
+                        await myAsyncOperation(value);
+                    },
+                },
+            ],
+            handler: async ({ value }) => {
+                // This will be called with "value-1" and "value-2"
+                await myAsyncOperation(value);
+            },
+        },
+    },
+});
+
+await broker
+    .subscription('from-all-topics')
+    .on('message', ({ value }) => {
+        console.log(value.id); // Print "value-1" and "value-2"
+    })
+    .on('message.my-topic-1', ({ value }) => {
+        console.log(value.id); // Print "value-1"
+    })
+    .on('message.my-topic-2', ({ value }) => {
+        console.log(value.id); // Print "value-2"
+    })
+    .run();
+
+await broker.publish('to-my-topic-1', { value: 'value-1' });
+await broker.publish('to-my-topic-2', { value: 'value-2' });
+```
+
+### Shutdown
+
+Shutdown the broker to disconnect all producers and consumers:
+
+```typescript
+await broker.shutdown();
+```
+
+### Broker container
+
+The `BrokerContainer` helps you to manage multiple `Broker` instance,
+helpful to compose a company broker.
+
+It shares the same interface as the `Broker` class.
+
+```typescript
+const broker = new BrokerContainer({
+    namespace: 'my-service',
+    brokers: {
+        public: {
+            config: {
+                brokers: [process.env.KAFKA_BROKER as string],
+            },
+            publications: {
+                'my-topic': 'my-long-topic-name',
+            },
+            subscriptions: {
+                'my-topic': 'my-long-topic-name',
+            },
+        },
+        private: {
+            config: {
+                brokers: [process.env.KAFKA_BROKER as string],
+            },
+            publications: {
+                'my-topic': 'my-long-topic-name',
+            },
+            subscriptions: {
+                'my-topic': 'my-long-topic-name',
+            },
+        },
+    },
+});
+
+await broker
+    .subscriptionList()
+    .on('message', ({ value }) => {
+        console.log(value); // Print "my-public-message" and "my-private-message"
+    })
+    .runAll();
+
+await broker.publish('public.my-topic', { value: 'my-public-message' });
+await broker.publish('private.my-topic', { value: 'my-private-message' });
+```
+
+## API
+
+...
+
+## License
+
+[MIT](LICENSE)

--- a/packages/kafka-broker/jest.config.js
+++ b/packages/kafka-broker/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    ...require('../../jest.config'),
+    globalSetup: './jest.setup.js',
+};

--- a/packages/kafka-broker/jest.setup.js
+++ b/packages/kafka-broker/jest.setup.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+    process.env.KAFKA_BROKER = process.env.KAFKA_BROKER || '192.168.0.10:9092';
+    process.env.KAFKAJS_LOG_LEVEL = 'nothing';
+};

--- a/packages/kafka-broker/package.json
+++ b/packages/kafka-broker/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@vpriem/kafka-broker",
+  "version": "1.0.0-alpha.1",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/vpriem/ts-monorepo.git",
+    "directory": "packages/kafka-broker"
+  },
+  "author": "V. Priem <vinzent.priem@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "kafka",
+    "kafkajs",
+    "broker",
+    "event"
+  ],
+  "engines": {
+    "node": ">=12.x",
+    "yarn": "^1.22.x"
+  },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "clean": "rimraf {dist,tsconfig.tsbuildinfo,yarn-error.log,coverage}",
+    "lint": "eslint --ext .ts ./src",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "kafkajs": "1.15.0"
+  },
+  "devDependencies": {
+    "@types/uuid": "8.3.0",
+    "uuid": "8.3.2"
+  }
+}

--- a/packages/kafka-broker/src/Broker.ts
+++ b/packages/kafka-broker/src/Broker.ts
@@ -1,0 +1,88 @@
+import { Kafka, RecordMetadata } from 'kafkajs';
+import { BrokerConfig, PublishMessage, PublishMessageValue } from './types';
+import { Subscription } from './Subscription';
+import { Config, buildConfig } from './buildConfig';
+import { encodeMessage } from './encodeMessage';
+import { BrokerInterface } from './BrokerInterface';
+import { BrokerError } from './BrokerError';
+import { ProducerContainer } from './ProducerContainer';
+import { SubscriptionContainer } from './SubscriptionContainer';
+import { SubscriptionList } from './SubscriptionList';
+
+export class Broker implements BrokerInterface {
+    private readonly config: Config;
+
+    private readonly kafka: Kafka;
+
+    private readonly producers: ProducerContainer;
+
+    private readonly subscriptions: SubscriptionContainer;
+
+    constructor(config: BrokerConfig) {
+        this.config = buildConfig(config);
+
+        this.kafka = new Kafka(this.config.config);
+        this.producers = new ProducerContainer(
+            this.kafka,
+            this.config.producers
+        );
+        this.subscriptions = new SubscriptionContainer(
+            this.kafka,
+            this.config.subscriptions
+        );
+    }
+
+    async publish<V = PublishMessageValue>(
+        publicationName: string,
+        messageOrMessages: PublishMessage<V> | PublishMessage<V>[]
+    ): Promise<RecordMetadata[]> {
+        const publicationConfig = this.config.publications[publicationName];
+        if (typeof publicationConfig === 'undefined') {
+            throw new BrokerError(`Unknown publication "${publicationName}"`);
+        }
+
+        const {
+            producer: producerName,
+            topic,
+            messageConfig,
+        } = publicationConfig;
+
+        const producer = await this.producers.create(producerName);
+
+        let messages = Array.isArray(messageOrMessages)
+            ? messageOrMessages
+            : [messageOrMessages];
+
+        if (messageConfig) {
+            messages = messages.map((message) => ({
+                ...messageConfig,
+                ...message,
+            }));
+        }
+
+        return producer.send({
+            ...publicationConfig.config,
+            topic,
+            messages: messages.map(encodeMessage),
+        });
+    }
+
+    subscription(name: string): Subscription {
+        return this.subscriptions.create(name);
+    }
+
+    subscriptionList(): SubscriptionList {
+        const subscriptions = Object.keys(this.config.subscriptions);
+
+        return new SubscriptionList(
+            ...subscriptions.map((name) => this.subscription(name))
+        );
+    }
+
+    async shutdown(): Promise<void> {
+        await Promise.all([
+            this.producers.disconnect(),
+            this.subscriptions.disconnect(),
+        ]);
+    }
+}

--- a/packages/kafka-broker/src/BrokerContainer.ts
+++ b/packages/kafka-broker/src/BrokerContainer.ts
@@ -1,0 +1,73 @@
+import { RecordMetadata } from 'kafkajs';
+import {
+    BrokerContainerConfig,
+    PublishMessage,
+    PublishMessageValue,
+} from './types';
+import { Broker } from './Broker';
+import { BrokerInterface } from './BrokerInterface';
+import { BrokerError } from './BrokerError';
+import { Subscription } from './Subscription';
+import { SubscriptionList } from './SubscriptionList';
+import { ContainerConfig, buildContainerConfig } from './buildContainerConfig';
+
+export class BrokerContainer implements BrokerInterface {
+    private readonly config: ContainerConfig;
+
+    private brokers: Record<string, Broker> = {};
+
+    constructor(config: BrokerContainerConfig) {
+        this.config = buildContainerConfig(config);
+    }
+
+    private createBroker(name: string): Broker {
+        if (typeof this.brokers[name] === 'undefined') {
+            const brokerConfig = this.config.brokers[name];
+            if (typeof brokerConfig === 'undefined') {
+                throw new BrokerError(`Unknown broker "${name}"`);
+            }
+
+            this.brokers[name] = new Broker(brokerConfig);
+        }
+
+        return this.brokers[name];
+    }
+
+    async publish<V = PublishMessageValue>(
+        brokerAndPublicationName: string,
+        messageOrMessages: PublishMessage<V> | PublishMessage<V>[]
+    ): Promise<RecordMetadata[]> {
+        const [brokerName, ...parts] = brokerAndPublicationName.split('/');
+
+        return this.createBroker(brokerName).publish<V>(
+            parts.join('/'),
+            messageOrMessages
+        );
+    }
+
+    subscription(brokerAndSubscriptionName: string): Subscription {
+        const [brokerName, ...parts] = brokerAndSubscriptionName.split('/');
+
+        return this.createBroker(brokerName).subscription(parts.join('/'));
+    }
+
+    subscriptionList(): SubscriptionList {
+        const brokers = Object.keys(this.config.brokers);
+
+        const nestedSubscriptions = brokers.map((name) =>
+            this.createBroker(name).subscriptionList()
+        );
+
+        return new SubscriptionList(...nestedSubscriptions.flat());
+    }
+
+    async shutdown(): Promise<void> {
+        const { brokers } = this;
+
+        this.brokers = {};
+
+        await Promise.all(
+            Object.values(brokers).map((broker) => broker.shutdown())
+        );
+    }
+}

--- a/packages/kafka-broker/src/BrokerError.ts
+++ b/packages/kafka-broker/src/BrokerError.ts
@@ -1,0 +1,1 @@
+export class BrokerError extends Error {}

--- a/packages/kafka-broker/src/BrokerInterface.ts
+++ b/packages/kafka-broker/src/BrokerInterface.ts
@@ -1,0 +1,22 @@
+import { RecordMetadata } from 'kafkajs';
+import { PublishMessage, PublishMessageValue } from './types';
+import { Subscription } from './Subscription';
+import { SubscriptionList } from './SubscriptionList';
+
+export interface BrokerInterface {
+    publish<V = PublishMessageValue>(
+        name: string,
+        message: PublishMessage<V>
+    ): Promise<RecordMetadata[]>;
+
+    publish<V = PublishMessageValue>(
+        name: string,
+        messages: PublishMessage<V>[]
+    ): Promise<RecordMetadata[]>;
+
+    subscription(name: string): Subscription;
+
+    subscriptionList(): SubscriptionList;
+
+    shutdown(): Promise<void>;
+}

--- a/packages/kafka-broker/src/Optional.ts
+++ b/packages/kafka-broker/src/Optional.ts
@@ -1,0 +1,1 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/packages/kafka-broker/src/ProducerContainer.ts
+++ b/packages/kafka-broker/src/ProducerContainer.ts
@@ -1,0 +1,50 @@
+import { Kafka, Producer, ProducerConfig } from 'kafkajs';
+import { ProducerMap } from './types';
+import { BrokerError } from './BrokerError';
+
+export class ProducerContainer {
+    private readonly kafka: Kafka;
+
+    private readonly config: ProducerMap;
+
+    private producers: Record<string, Promise<Producer>> = {};
+
+    constructor(kafka: Kafka, config: ProducerMap) {
+        this.kafka = kafka;
+        this.config = config;
+    }
+
+    private async createAndConnect(config?: ProducerConfig): Promise<Producer> {
+        const producer = this.kafka.producer(config);
+
+        await producer.connect();
+
+        return producer;
+    }
+
+    async create(name: string): Promise<Producer> {
+        if (typeof this.producers[name] === 'undefined') {
+            const producerConfig = this.config[name];
+            if (typeof producerConfig === 'undefined') {
+                throw new BrokerError(`Unknown producer "${name}"`);
+            }
+
+            this.producers[name] = this.createAndConnect(producerConfig.config);
+        }
+
+        return this.producers[name];
+    }
+
+    async disconnect(): Promise<void> {
+        const { producers } = this;
+
+        this.producers = {};
+
+        await Promise.all(
+            Object.values(producers).map(async (promise) => {
+                const producer = await promise;
+                return producer.disconnect();
+            })
+        );
+    }
+}

--- a/packages/kafka-broker/src/Subscription.ts
+++ b/packages/kafka-broker/src/Subscription.ts
@@ -1,0 +1,94 @@
+import EventEmitter from 'events';
+import { Consumer } from 'kafkajs';
+import { decodeMessage } from './decodeMessage';
+import { SubscriptionConfigProcessed } from './buildConfig';
+
+export class Subscription extends EventEmitter {
+    readonly name: string;
+
+    private readonly consumer: Consumer;
+
+    private readonly config: SubscriptionConfigProcessed;
+
+    private isRunning = false;
+
+    constructor(
+        consumer: Consumer,
+        name: string,
+        config: SubscriptionConfigProcessed
+    ) {
+        super();
+
+        this.consumer = consumer;
+        this.name = name;
+        this.config = config;
+
+        this.registerHandlers();
+    }
+
+    private registerHandlers() {
+        if (this.config.handler) {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            this.on('message', this.config.handler);
+        }
+
+        this.config.topics.forEach(({ topic, alias, handler }) => {
+            if (handler) {
+                // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                this.on(`message.${alias || topic.toString()}`, handler);
+            }
+        });
+    }
+
+    private mapTopicToAlias(): Record<string, string> {
+        return this.config.topics.reduce<Record<string, string>>(
+            (acc, { topic, alias }) => {
+                acc[topic.toString()] = alias || topic.toString();
+                return acc;
+            },
+            {}
+        );
+    }
+
+    private async subscribe(): Promise<void> {
+        await this.consumer.connect();
+
+        await Promise.all(
+            this.config.topics.map((topicConfig) =>
+                this.consumer.subscribe(topicConfig)
+            )
+        );
+    }
+
+    async run(): Promise<this> {
+        if (this.isRunning) return this;
+        this.isRunning = true;
+
+        const topicToAlias = this.mapTopicToAlias();
+
+        await this.subscribe();
+
+        await this.consumer.run({
+            ...this.config.runConfig,
+            eachMessage: async (payload) => {
+                const message = decodeMessage(payload.message);
+
+                this.emit('message', message, payload);
+
+                const topicAlias = topicToAlias[payload.topic];
+                // istanbul ignore else
+                if (topicAlias) {
+                    this.emit(`message.${topicAlias}`, message, payload);
+                }
+
+                return Promise.resolve();
+            },
+        });
+
+        return this;
+    }
+
+    async disconnect(): Promise<void> {
+        return this.consumer.disconnect();
+    }
+}

--- a/packages/kafka-broker/src/SubscriptionContainer.ts
+++ b/packages/kafka-broker/src/SubscriptionContainer.ts
@@ -1,0 +1,46 @@
+import { Kafka } from 'kafkajs';
+import { Subscription } from './Subscription';
+import { BrokerError } from './BrokerError';
+import { Config } from './buildConfig';
+
+export class SubscriptionContainer {
+    private readonly kafka: Kafka;
+
+    private readonly config: Config['subscriptions'];
+
+    private subscriptions: Record<string, Subscription> = {};
+
+    constructor(kafka: Kafka, config: Config['subscriptions']) {
+        this.kafka = kafka;
+        this.config = config;
+    }
+
+    create(name: string): Subscription {
+        if (typeof this.subscriptions[name] === 'undefined') {
+            const subscriptionConfig = this.config[name];
+            if (typeof subscriptionConfig === 'undefined') {
+                throw new BrokerError(`Unknown subscription "${name}"`);
+            }
+
+            this.subscriptions[name] = new Subscription(
+                this.kafka.consumer(subscriptionConfig.consumer),
+                name,
+                subscriptionConfig
+            );
+        }
+
+        return this.subscriptions[name];
+    }
+
+    async disconnect(): Promise<void> {
+        const { subscriptions } = this;
+
+        this.subscriptions = {};
+
+        await Promise.all(
+            Object.values(subscriptions).map((subscription) =>
+                subscription.disconnect()
+            )
+        );
+    }
+}

--- a/packages/kafka-broker/src/SubscriptionList.ts
+++ b/packages/kafka-broker/src/SubscriptionList.ts
@@ -1,0 +1,18 @@
+import { Subscription } from './Subscription';
+import { AsyncHandler, Handler } from './types';
+
+export class SubscriptionList extends Array<Subscription> {
+    on(event: 'message', handler: Handler | AsyncHandler): this {
+        this.forEach((subscription) => {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            subscription.on('message', handler);
+        });
+
+        return this;
+    }
+
+    async runAll(): Promise<this> {
+        await Promise.all(this.map((subscription) => subscription.run()));
+        return this;
+    }
+}

--- a/packages/kafka-broker/src/buildConfig.ts
+++ b/packages/kafka-broker/src/buildConfig.ts
@@ -1,0 +1,110 @@
+import {
+    BrokerConfig,
+    ConsumerConfig,
+    ProducerMap,
+    PublicationConfig,
+    PublicationMap,
+    SubscriptionConfig,
+    SubscriptionMap,
+    TopicConfig,
+} from './types';
+
+export interface SubscriptionConfigProcessed extends SubscriptionConfig {
+    consumer: ConsumerConfig;
+    topics: TopicConfig[];
+}
+
+export interface Config extends BrokerConfig {
+    producers: ProducerMap;
+    publications: Record<
+        string,
+        PublicationConfig & {
+            producer: string;
+        }
+    >;
+    subscriptions: Record<string, SubscriptionConfigProcessed>;
+}
+
+const buildPublications = (
+    publications: PublicationMap = {}
+): Config['publications'] =>
+    Object.keys(publications).reduce<Config['publications']>((acc, name) => {
+        const publicationConfig = publications[name];
+        if (typeof publicationConfig === 'string') {
+            acc[name] = {
+                producer: 'default',
+                topic: publicationConfig,
+            };
+        } else {
+            acc[name] = {
+                producer: 'default',
+                ...publicationConfig,
+            };
+        }
+        return acc;
+    }, {});
+
+const buildTopics = (topics: SubscriptionConfig['topics']): TopicConfig[] => {
+    if (typeof topics === 'string') {
+        return [{ topic: topics }];
+    }
+
+    if (Array.isArray(topics)) {
+        return topics.map((topic) =>
+            typeof topic === 'string' ? { topic } : topic
+        );
+    }
+
+    return [topics];
+};
+
+const isTopicConfig = (
+    config: SubscriptionConfig | TopicConfig
+): config is TopicConfig => (config as TopicConfig).topic !== undefined;
+
+const buildSubscriptions = (
+    subscriptions: SubscriptionMap = {},
+    namespace: string
+): Config['subscriptions'] =>
+    Object.keys(subscriptions).reduce<Config['subscriptions']>((acc, name) => {
+        const consumer = { groupId: `${namespace}.${name}` };
+        const subscriptionConfig = subscriptions[name];
+
+        if (
+            typeof subscriptionConfig === 'string' ||
+            Array.isArray(subscriptionConfig) ||
+            isTopicConfig(subscriptionConfig)
+        ) {
+            acc[name] = {
+                consumer,
+                topics: buildTopics(subscriptionConfig),
+            };
+
+            return acc;
+        }
+
+        acc[name] = {
+            consumer: {
+                ...consumer,
+                ...subscriptionConfig.consumer,
+            },
+            ...subscriptionConfig,
+            topics: buildTopics(subscriptionConfig.topics),
+        };
+
+        return acc;
+    }, {});
+
+export const buildConfig = (config: BrokerConfig): Config => ({
+    ...config,
+    config: {
+        clientId: config.namespace,
+        ...config.config,
+    },
+    producers: {
+        default: {},
+        ...config.producers,
+    },
+    publications: buildPublications(config.publications),
+    subscriptions: buildSubscriptions(config.subscriptions, config.namespace),
+});

--- a/packages/kafka-broker/src/buildContainerConfig.ts
+++ b/packages/kafka-broker/src/buildContainerConfig.ts
@@ -1,0 +1,22 @@
+import { BrokerConfig, BrokerContainerConfig } from './types';
+
+export interface ContainerConfig extends BrokerContainerConfig {
+    brokers: Record<string, BrokerConfig>;
+}
+
+export const buildContainerConfig = ({
+    namespace,
+    brokers,
+}: BrokerContainerConfig): ContainerConfig => ({
+    namespace,
+    brokers: Object.keys(brokers).reduce<ContainerConfig['brokers']>(
+        (acc, brokerName) => {
+            acc[brokerName] = {
+                namespace,
+                ...brokers[brokerName],
+            };
+            return acc;
+        },
+        {}
+    ),
+});

--- a/packages/kafka-broker/src/decodeMessage.ts
+++ b/packages/kafka-broker/src/decodeMessage.ts
@@ -1,0 +1,20 @@
+import { KafkaMessage } from 'kafkajs';
+import { ConsumeMessage } from './types';
+
+export const decodeMessage = (message: KafkaMessage): ConsumeMessage => {
+    if (!message.value) return message;
+
+    const contentType = message.headers?.['content-type']?.toString();
+
+    if (contentType === 'application/json') {
+        return {
+            ...message,
+            value: JSON.parse(message.value.toString()) as object,
+        };
+    }
+
+    return {
+        ...message,
+        value: message.value.toString(),
+    };
+};

--- a/packages/kafka-broker/src/encodeMessage.ts
+++ b/packages/kafka-broker/src/encodeMessage.ts
@@ -1,0 +1,16 @@
+import { Message } from 'kafkajs';
+import { PublishMessage, PublishMessageValue } from './types';
+
+export const encodeMessage = <V = PublishMessageValue>(
+    message: PublishMessage<V>
+): Message =>
+    (typeof message.value === 'object'
+        ? {
+              ...message,
+              value: JSON.stringify(message.value),
+              headers: {
+                  ...message.headers,
+                  'content-type': 'application/json',
+              },
+          }
+        : message) as Message;

--- a/packages/kafka-broker/src/index.ts
+++ b/packages/kafka-broker/src/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './Broker';
+export * from './BrokerContainer';
+export * from './BrokerError';
+export * from './Subscription';

--- a/packages/kafka-broker/src/tests/broker+container.test.ts
+++ b/packages/kafka-broker/src/tests/broker+container.test.ts
@@ -1,0 +1,76 @@
+import { v4 as uuid } from 'uuid';
+import { BrokerContainer, BrokerError, ConsumeMessage } from '..';
+
+interface Event {
+    id: number;
+}
+
+describe('broker+container', () => {
+    const topic1 = uuid();
+    const topic2 = uuid();
+    const broker = new BrokerContainer({
+        namespace: uuid(),
+        brokers: {
+            public: {
+                config: {
+                    brokers: [process.env.KAFKA_BROKER as string],
+                },
+                publications: {
+                    'to-topic1': topic1,
+                },
+                subscriptions: {
+                    'from-topic1': topic1,
+                },
+            },
+            private: {
+                config: {
+                    brokers: [process.env.KAFKA_BROKER as string],
+                },
+                publications: {
+                    'to-topic2': topic2,
+                },
+                subscriptions: {
+                    'from-topic2': topic2,
+                },
+            },
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should throw BrokerError', async () => {
+        await expect(broker.publish('foo/bar', { value: 'a' })).rejects.toThrow(
+            new BrokerError('Unknown broker "foo"')
+        );
+
+        expect(() => broker.subscription('foo/bar')).toThrow(
+            new BrokerError('Unknown broker "foo"')
+        );
+    });
+
+    it('should publish and consume from all brokers', async () => {
+        const values: number[] = [];
+
+        const subscriptions = broker.subscriptionList();
+        expect(subscriptions).toHaveLength(2);
+
+        const promise = new Promise((resolve) => {
+            subscriptions.on('message', (message: ConsumeMessage<Event>) => {
+                values.push(message.value.id);
+                if (values.length >= 2) resolve(values);
+            });
+        });
+
+        await subscriptions.runAll();
+
+        await expect(
+            broker.publish<Event>('public/to-topic1', { value: { id: 1 } })
+        ).resolves.toMatchObject([{ topicName: topic1 }]);
+
+        await expect(
+            broker.publish<Event>('private/to-topic2', { value: { id: 2 } })
+        ).resolves.toMatchObject([{ topicName: topic2 }]);
+
+        await expect(promise).resolves.toEqual(expect.arrayContaining([1, 2]));
+    });
+});

--- a/packages/kafka-broker/src/tests/broker+error.test.ts
+++ b/packages/kafka-broker/src/tests/broker+error.test.ts
@@ -1,0 +1,34 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, BrokerError } from '..';
+
+describe('broker+error', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': {
+                topic,
+                producer: 'foo',
+            },
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should throw BrokerError', async () => {
+        await expect(broker.publish('foo', { value: 'a' })).rejects.toThrow(
+            new BrokerError('Unknown publication "foo"')
+        );
+
+        await expect(
+            broker.publish('to-topic1', { value: 'a' })
+        ).rejects.toThrow(new BrokerError('Unknown producer "foo"'));
+
+        expect(() => broker.subscription('foo')).toThrow(
+            new BrokerError('Unknown subscription "foo"')
+        );
+    });
+});

--- a/packages/kafka-broker/src/tests/config.test.ts
+++ b/packages/kafka-broker/src/tests/config.test.ts
@@ -1,0 +1,147 @@
+import { buildConfig } from '../buildConfig';
+
+describe('config', () => {
+    it('should build config', () => {
+        expect(
+            buildConfig({
+                namespace: 'my-service',
+                config: {
+                    brokers: [process.env.KAFKA_BROKER as string],
+                },
+                producers: {
+                    'my-producer-2': {
+                        config: { allowAutoTopicCreation: false },
+                    },
+                },
+                publications: {
+                    'to-topic1': 'my-topic-1',
+                    'to-topic2': {
+                        topic: 'my-topic-2',
+                        producer: 'my-producer-2',
+                    },
+                },
+                subscriptions: {
+                    'from-topic0': 'my-topic-0',
+                    'from-topic1': {
+                        topic: 'my-topic-1',
+                        alias: 'alias-to-my-topic1',
+                    },
+                    'from-topic2': {
+                        topics: [
+                            {
+                                topic: 'my-topic-2',
+                                fromBeginning: true,
+                            },
+                        ],
+                    },
+                    'from-topic3': {
+                        topics: 'my-topic-3',
+                        consumer: { groupId: 'my-group-id-3' },
+                    },
+                    'from-all-topics': [
+                        'my-topic-0',
+                        'my-topic-1',
+                        'my-topic-2',
+                        'my-topic-3',
+                    ],
+                    'from-all-again': [
+                        { topic: 'my-topic-0' },
+                        { topic: 'my-topic-1' },
+                        { topic: 'my-topic-2' },
+                        { topic: 'my-topic-3' },
+                    ],
+                },
+            })
+        ).toEqual({
+            namespace: 'my-service',
+            config: {
+                clientId: 'my-service',
+                brokers: [process.env.KAFKA_BROKER as string],
+            },
+            producers: {
+                default: {},
+                'my-producer-2': {
+                    config: { allowAutoTopicCreation: false },
+                },
+            },
+            publications: {
+                'to-topic1': {
+                    topic: 'my-topic-1',
+                    producer: 'default',
+                },
+                'to-topic2': {
+                    topic: 'my-topic-2',
+                    producer: 'my-producer-2',
+                },
+            },
+            subscriptions: {
+                'from-topic0': {
+                    topics: [{ topic: 'my-topic-0' }],
+                    consumer: { groupId: 'my-service.from-topic0' },
+                },
+                'from-topic1': {
+                    topics: [
+                        {
+                            topic: 'my-topic-1',
+                            alias: 'alias-to-my-topic1',
+                        },
+                    ],
+                    consumer: { groupId: 'my-service.from-topic1' },
+                },
+                'from-topic2': {
+                    topics: [
+                        {
+                            topic: 'my-topic-2',
+                            fromBeginning: true,
+                        },
+                    ],
+                    consumer: { groupId: 'my-service.from-topic2' },
+                },
+                'from-topic3': {
+                    topics: [{ topic: 'my-topic-3' }],
+                    consumer: { groupId: 'my-group-id-3' },
+                },
+                'from-all-topics': {
+                    topics: [
+                        { topic: 'my-topic-0' },
+                        { topic: 'my-topic-1' },
+                        { topic: 'my-topic-2' },
+                        { topic: 'my-topic-3' },
+                    ],
+                    consumer: { groupId: 'my-service.from-all-topics' },
+                },
+                'from-all-again': {
+                    topics: [
+                        { topic: 'my-topic-0' },
+                        { topic: 'my-topic-1' },
+                        { topic: 'my-topic-2' },
+                        { topic: 'my-topic-3' },
+                    ],
+                    consumer: { groupId: 'my-service.from-all-again' },
+                },
+            },
+        });
+    });
+
+    it('should build config from empty', () => {
+        expect(
+            buildConfig({
+                namespace: 'my-service',
+                config: {
+                    brokers: [process.env.KAFKA_BROKER as string],
+                },
+            })
+        ).toEqual({
+            namespace: 'my-service',
+            config: {
+                clientId: 'my-service',
+                brokers: [process.env.KAFKA_BROKER as string],
+            },
+            producers: {
+                default: {},
+            },
+            publications: {},
+            subscriptions: {},
+        });
+    });
+});

--- a/packages/kafka-broker/src/tests/container+config.test.ts
+++ b/packages/kafka-broker/src/tests/container+config.test.ts
@@ -1,0 +1,40 @@
+import { buildContainerConfig } from '../buildContainerConfig';
+
+describe('container+config', () => {
+    it('should build container config', () => {
+        expect(
+            buildContainerConfig({
+                namespace: 'my-service',
+                brokers: {
+                    broker1: {
+                        config: {
+                            brokers: [process.env.KAFKA_BROKER as string],
+                        },
+                    },
+                    broker2: {
+                        namespace: 'my-service.broker2',
+                        config: {
+                            brokers: [process.env.KAFKA_BROKER as string],
+                        },
+                    },
+                },
+            })
+        ).toEqual({
+            namespace: 'my-service',
+            brokers: {
+                broker1: {
+                    namespace: 'my-service',
+                    config: {
+                        brokers: [process.env.KAFKA_BROKER as string],
+                    },
+                },
+                broker2: {
+                    namespace: 'my-service.broker2',
+                    config: {
+                        brokers: [process.env.KAFKA_BROKER as string],
+                    },
+                },
+            },
+        });
+    });
+});

--- a/packages/kafka-broker/src/tests/handlers.test.ts
+++ b/packages/kafka-broker/src/tests/handlers.test.ts
@@ -1,0 +1,85 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, Handler } from '..';
+
+interface Event {
+    id: number;
+}
+
+describe('handlers', () => {
+    const topic1 = uuid();
+    const topic2 = uuid();
+    const handler: Handler = jest.fn();
+    const handlerOfTopic1: Handler = jest.fn();
+    const handlerOfTopic2: Handler = jest.fn();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic1,
+            'to-topic2': topic2,
+        },
+        subscriptions: {
+            'from-all-topics': {
+                topics: [
+                    {
+                        topic: topic1,
+                        handler: handlerOfTopic1,
+                    },
+                    {
+                        topic: topic2,
+                        handler: handlerOfTopic2,
+                    },
+                ],
+                handler,
+            },
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should call handler', async () => {
+        let calls = 0;
+        const subscription = broker.subscription('from-all-topics');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', () => {
+                calls += 1;
+                if (calls >= 2) resolve(calls);
+            });
+        });
+
+        await subscription.run();
+
+        await expect(
+            broker.publish<Event>('to-topic1', { value: { id: 123 } })
+        ).resolves.toMatchObject([{ topicName: topic1 }]);
+
+        await expect(
+            broker.publish<Event>('to-topic2', { value: { id: 321 } })
+        ).resolves.toMatchObject([{ topicName: topic2 }]);
+
+        await expect(promise).resolves.toBe(2);
+
+        expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({ value: { id: 123 } }),
+            expect.objectContaining({ topic: topic1 })
+        );
+
+        expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({ value: { id: 321 } }),
+            expect.objectContaining({ topic: topic2 })
+        );
+
+        expect(handlerOfTopic1).toHaveBeenCalledWith(
+            expect.objectContaining({ value: { id: 123 } }),
+            expect.objectContaining({ topic: topic1 })
+        );
+
+        expect(handlerOfTopic2).toHaveBeenCalledWith(
+            expect.objectContaining({ value: { id: 321 } }),
+            expect.objectContaining({ topic: topic2 })
+        );
+    });
+});

--- a/packages/kafka-broker/src/tests/publish+config.test.ts
+++ b/packages/kafka-broker/src/tests/publish+config.test.ts
@@ -1,0 +1,57 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+describe('publish+config', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': {
+                topic,
+                messageConfig: { key: 'default-key' },
+            },
+        },
+        subscriptions: {
+            'from-topic1': {
+                topics: [{ topic, fromBeginning: true }],
+            },
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should publish and consume with config', async () => {
+        const values: string[] = [];
+        const keys: string[] = [];
+
+        await expect(
+            broker.publish('to-topic1', [
+                { value: 'foo' },
+                { key: 'key-of-bar', value: 'bar' },
+            ])
+        ).resolves.toMatchObject([{ topicName: topic }]);
+
+        const subscription = broker.subscription('from-topic1');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', (message: ConsumeMessage<string>) => {
+                values.push(message.value);
+                keys.push(message.key.toString());
+                if (values.length >= 2) resolve(values);
+            });
+        });
+
+        await subscription.run();
+
+        await expect(promise).resolves.toEqual(
+            expect.arrayContaining(['foo', 'bar'])
+        );
+
+        expect(keys).toEqual(
+            expect.arrayContaining(['default-key', 'key-of-bar'])
+        );
+    });
+});

--- a/packages/kafka-broker/src/tests/publish+json.test.ts
+++ b/packages/kafka-broker/src/tests/publish+json.test.ts
@@ -1,0 +1,61 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+interface Event {
+    id: number;
+}
+
+describe('publish+json', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic,
+        },
+        subscriptions: {
+            'from-topic1': topic,
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should publish and consume', async () => {
+        const values: number[] = [];
+        const headers: Array<string | undefined> = [];
+
+        const subscription = broker.subscription('from-topic1');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', (message: ConsumeMessage<Event>) => {
+                headers.push(message.headers?.['content-type']?.toString());
+                values.push(message.value.id);
+                if (values.length >= 4) resolve(values);
+            });
+        });
+
+        await subscription.run();
+
+        await expect(
+            broker.publish<Event>('to-topic1', [
+                { value: { id: 1 } },
+                { value: { id: 2 } },
+                { value: { id: 3 } },
+                { value: { id: 4 } },
+            ])
+        ).resolves.toMatchObject([{ topicName: topic }]);
+
+        await expect(promise).resolves.toEqual(
+            expect.arrayContaining([1, 2, 3, 4])
+        );
+
+        expect(headers).toEqual([
+            'application/json',
+            'application/json',
+            'application/json',
+            'application/json',
+        ]);
+    });
+});

--- a/packages/kafka-broker/src/tests/publish+null.test.ts
+++ b/packages/kafka-broker/src/tests/publish+null.test.ts
@@ -1,0 +1,38 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+describe('publish+null', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic,
+        },
+        subscriptions: {
+            'from-topic1': topic,
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should publish and consume', async () => {
+        const subscription = broker.subscription('from-topic1');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', (message: ConsumeMessage<null>) => {
+                resolve(message.value);
+            });
+        });
+
+        await subscription.run();
+
+        await expect(
+            broker.publish('to-topic1', { value: null })
+        ).resolves.toMatchObject([{ topicName: topic }]);
+
+        await expect(promise).resolves.toBeNull();
+    });
+});

--- a/packages/kafka-broker/src/tests/publish+string.test.ts
+++ b/packages/kafka-broker/src/tests/publish+string.test.ts
@@ -1,0 +1,38 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+describe('publish+string', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic,
+        },
+        subscriptions: {
+            'from-topic1': topic,
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should publish and consume', async () => {
+        const subscription = broker.subscription('from-topic1');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', (message: ConsumeMessage<string>) => {
+                resolve(message.value);
+            });
+        });
+
+        await subscription.run();
+
+        await expect(
+            broker.publish('to-topic1', { value: 'foo' })
+        ).resolves.toMatchObject([{ topicName: topic }]);
+
+        await expect(promise).resolves.toBe('foo');
+    });
+});

--- a/packages/kafka-broker/src/tests/subscribe+all.test.ts
+++ b/packages/kafka-broker/src/tests/subscribe+all.test.ts
@@ -1,0 +1,53 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+interface Event {
+    id: number;
+}
+
+describe('subscribe+all', () => {
+    const topic1 = uuid();
+    const topic2 = uuid();
+    const broker = new Broker({
+        namespace: 'service1',
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic1,
+            'to-topic2': topic2,
+        },
+        subscriptions: {
+            'from-topic1': topic1,
+            'from-topic2': topic2,
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should publish and consume from all', async () => {
+        const values: number[] = [];
+
+        const subscriptions = broker.subscriptionList();
+        expect(subscriptions).toHaveLength(2);
+
+        const promise = new Promise((resolve) => {
+            subscriptions.on('message', (message: ConsumeMessage<Event>) => {
+                values.push(message.value.id);
+                if (values.length >= 2) resolve(values);
+            });
+        });
+
+        await subscriptions.runAll();
+
+        await expect(
+            broker.publish<Event>('to-topic1', { value: { id: 1 } })
+        ).resolves.toMatchObject([{ topicName: topic1 }]);
+
+        await expect(
+            broker.publish<Event>('to-topic2', { value: { id: 2 } })
+        ).resolves.toMatchObject([{ topicName: topic2 }]);
+
+        await expect(promise).resolves.toEqual(expect.arrayContaining([1, 2]));
+    });
+});

--- a/packages/kafka-broker/src/tests/subscribe+run+once.test.ts
+++ b/packages/kafka-broker/src/tests/subscribe+run+once.test.ts
@@ -1,0 +1,44 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, ConsumeMessage } from '..';
+
+interface Event {
+    id: number;
+}
+
+describe('subscribe+run+once', () => {
+    const topic = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic,
+        },
+        subscriptions: {
+            'from-topic1': topic,
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should subscribe and run once', async () => {
+        broker.subscription('from-topic1');
+        const subscription = broker.subscription('from-topic1');
+
+        const promise = new Promise((resolve) => {
+            subscription.on('message', (message: ConsumeMessage<Event>) => {
+                resolve(message.value.id);
+            });
+        });
+
+        await subscription.run();
+        await subscription.run();
+
+        await expect(
+            broker.publish<Event>('to-topic1', { value: { id: 999 } })
+        ).resolves.toMatchObject([{ topicName: topic }]);
+
+        await expect(promise).resolves.toBe(999);
+    });
+});

--- a/packages/kafka-broker/src/types.ts
+++ b/packages/kafka-broker/src/types.ts
@@ -1,0 +1,85 @@
+import {
+    ConsumerConfig as KafkaConsumerConfig,
+    ConsumerRunConfig,
+    ConsumerSubscribeTopic,
+    EachMessagePayload,
+    KafkaConfig,
+    KafkaMessage,
+    Message,
+    ProducerConfig as KafkaProducerConfig,
+    ProducerRecord,
+} from 'kafkajs';
+import { Optional } from './Optional';
+
+export interface ProducerConfig {
+    config?: KafkaProducerConfig;
+}
+
+export type MessageConfig = Omit<Message, 'value'>;
+
+export interface PublicationConfig {
+    producer?: string;
+    topic: string;
+    config?: Omit<ProducerRecord, 'topic' | 'messages'>;
+    messageConfig?: MessageConfig;
+}
+
+export type PublishMessageValue = Buffer | string | null | object;
+
+export interface PublishMessage<V = PublishMessageValue>
+    extends Omit<Message, 'value'> {
+    value: V;
+}
+
+export type ConsumerConfig = KafkaConsumerConfig;
+
+export type ConsumePayload = EachMessagePayload;
+
+export interface ConsumeMessage<V = string | null | object>
+    extends Omit<KafkaMessage, 'value'> {
+    value: V;
+}
+
+export type RunConfig = Omit<ConsumerRunConfig, 'eachBatch' | 'eachMessage'>;
+
+export type Handler = (
+    message: ConsumeMessage,
+    payload: ConsumePayload
+) => void;
+
+export type AsyncHandler = (
+    message: ConsumeMessage,
+    payload: ConsumePayload
+) => Promise<void>;
+
+export interface TopicConfig extends ConsumerSubscribeTopic {
+    alias?: string;
+    handler?: Handler | AsyncHandler;
+}
+
+export interface SubscriptionConfig {
+    consumer?: ConsumerConfig;
+    topics: string | TopicConfig | Array<string | TopicConfig>;
+    runConfig?: RunConfig;
+    handler?: Handler | AsyncHandler;
+}
+
+export type ProducerMap = Record<string, ProducerConfig>;
+export type PublicationMap = Record<string, string | PublicationConfig>;
+export type SubscriptionMap = Record<
+    string,
+    SubscriptionConfig['topics'] | SubscriptionConfig
+>;
+
+export interface BrokerConfig {
+    namespace: string;
+    config: KafkaConfig;
+    producers?: ProducerMap;
+    publications?: PublicationMap;
+    subscriptions?: SubscriptionMap;
+}
+
+export interface BrokerContainerConfig {
+    namespace: string;
+    brokers: Record<string, Optional<BrokerConfig, 'namespace'>>;
+}

--- a/packages/kafka-broker/tsconfig.eslint.json
+++ b/packages/kafka-broker/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.eslint.json"
+}

--- a/packages/kafka-broker/tsconfig.json
+++ b/packages/kafka-broker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/uuid@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -5561,6 +5566,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+kafkajs@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.15.0.tgz#a5ada0d933edca2149177393562be6fb0875ec3a"
+  integrity sha512-yjPyEnQCkPxAuQLIJnY5dI+xnmmgXmhuOQ1GVxClG5KTOV/rJcW1qA3UfvyEJKTp/RTSqQnUR3HJsKFvHyTpNg==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -8713,15 +8723,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@8.3.2, uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"


### PR DESCRIPTION
fix(kafka-broker): add groupId to consumer config

feat(kafka-broker): rename BrokerConfig.kafka to BrokerConfig.config

feat(kafka-broker): make similar api between Broker/BrokerContainer

feat(kafka-broker): test application/json header is set

feat(kafka-broker): add BrokerInterface.ts

feat(kafka-broker): move subscriptions to root

feat(kafka-broker): make BrokerConfig optional

feat(kafka-broker): add name to Subscription

feat(kafka-broker): add TopicMap

feat(kafka-broker): move consumer to subscriptions

feat(kafka-broker): add handlers

feat(kafka-broker): document API

docs(kafka-broker): write README.md

feat(kafka-broker): add buildConfig

feat(kafka-broker): restructure utils

feat(kafka-broker): build config

feat(kafka-broker): build config for BrokerContainer.ts

feat(kafka-broker): test coverage

feat(kafka-broker): style tests

feat(kafka-broker): improve SubscriptionMap

feat(kafka-broker): refactor subscription topics

feat(kafka-broker): document usage

feat(kafka-broker): add test pipeline

feat(kafka-broker): add SubscriptionList.on