### PR TITLE
feat(kafka-broker): rewrite on('message') to wait for each message to be fully processed

### DIFF
--- a/packages/kafka-broker/src/SubscriptionList.ts
+++ b/packages/kafka-broker/src/SubscriptionList.ts
@@ -4,18 +4,28 @@ export class SubscriptionList
     extends Array<SubscriptionInterface>
     implements SubscriptionInterface
 {
-    on<V = MessageValue>(event: string, listener: Handler<V>): this {
-        this.forEach((subscription) => subscription.on('message', listener));
+    on<V = MessageValue>(
+        event: 'message' | `message.${string}` | 'error',
+        listener: Handler<V> | ((error: Error) => void)
+    ): this {
+        this.forEach((subscription) =>
+            subscription.on(event as 'message', listener as Handler<V>)
+        );
         return this;
     }
 
-    once<V = MessageValue>(event: string, listener: Handler<V>): this {
-        this.forEach((subscription) => subscription.once('message', listener));
+    once(event: 'error', listener: (error: Error) => void): this {
+        this.forEach((subscription) => subscription.once(event, listener));
         return this;
     }
 
-    off<V = MessageValue>(event: string, listener: Handler<V>): this {
-        this.forEach((subscription) => subscription.off('message', listener));
+    off<V = MessageValue>(
+        event: 'message' | 'error',
+        listener: Handler<V> | ((error: Error) => void)
+    ): this {
+        this.forEach((subscription) =>
+            subscription.off(event as 'message', listener as Handler<V>)
+        );
         return this;
     }
 

--- a/packages/kafka-broker/src/tests/broker+container.test.ts
+++ b/packages/kafka-broker/src/tests/broker+container.test.ts
@@ -81,7 +81,6 @@ describe('broker+container', () => {
             .run();
 
         const subscription = broker.subscription('private/from-topic2');
-
         const message = getMessage(subscription);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/broker.test.ts
+++ b/packages/kafka-broker/src/tests/broker.test.ts
@@ -15,6 +15,9 @@ describe('broker', () => {
                 producer: 'foo',
             },
         },
+        subscriptions: {
+            'from-topic-foo': topic,
+        },
     });
 
     afterAll(() => broker.shutdown());
@@ -36,4 +39,18 @@ describe('broker', () => {
         expect(() => broker.subscription('foo')).toThrow(
             new BrokerError('Unknown subscription "foo"')
         ));
+
+    it('should throw on unknown topic', () =>
+        expect(() =>
+            broker
+                .subscription('from-topic-foo')
+                .on('message.foo', () => Promise.resolve())
+        ).toThrow(new BrokerError('Unknown topic or alias "foo"')));
+
+    it('should throw on unknown topic', () =>
+        expect(() =>
+            broker
+                .subscription('from-topic-foo')
+                .off('message.foo', () => Promise.resolve())
+        ).toThrow(new BrokerError('Unknown topic or alias "foo"')));
 });

--- a/packages/kafka-broker/src/tests/config.test.ts
+++ b/packages/kafka-broker/src/tests/config.test.ts
@@ -32,6 +32,7 @@ describe('config', () => {
                         {
                             topic: 'my-topic-1.1',
                             alias: 'alias-to-my-topic1',
+                            handler: async () => Promise.resolve(),
                         },
                     ],
                     'from-topic2': {
@@ -41,6 +42,7 @@ describe('config', () => {
                                 fromBeginning: true,
                             },
                         ],
+                        handler: async () => Promise.resolve(),
                     },
                     'from-topic3': {
                         topics: ['my-topic-3'],
@@ -111,6 +113,7 @@ describe('config', () => {
                         {
                             topic: 'my-topic-1.1',
                             alias: 'alias-to-my-topic1',
+                            handler: expect.any(Function) as Function,
                         },
                     ],
                     consumer: { groupId: 'my-service.from-topic1' },
@@ -124,6 +127,7 @@ describe('config', () => {
                         },
                     ],
                     consumer: { groupId: 'my-service.from-topic2' },
+                    handler: expect.any(Function) as Function,
                 },
                 'from-topic3': {
                     kafka: 'default',

--- a/packages/kafka-broker/src/tests/handler+publish.test.ts
+++ b/packages/kafka-broker/src/tests/handler+publish.test.ts
@@ -1,12 +1,9 @@
 import { v4 as uuid } from 'uuid';
-import { Broker, Handler, getMessage } from '..';
+import { Broker, getMessage } from '..';
 
 describe('handler+publish', () => {
     const topic1 = uuid();
     const topic2 = uuid();
-    const handler: Handler = async (value, payload, publish): Promise<void> => {
-        await publish('to-topic2', { value });
-    };
     const broker = new Broker({
         namespace: uuid(),
         config: {
@@ -19,7 +16,9 @@ describe('handler+publish', () => {
         subscriptions: {
             'from-topic1': {
                 topics: [topic1],
-                handler,
+                handler: async (value, payload, publish): Promise<void> => {
+                    await publish('to-topic2', { value });
+                },
             },
             'from-topic2': topic2,
         },

--- a/packages/kafka-broker/src/tests/handler+topic.test.ts
+++ b/packages/kafka-broker/src/tests/handler+topic.test.ts
@@ -1,0 +1,143 @@
+import { v4 as uuid } from 'uuid';
+import { Broker, Handler, getMessage } from '..';
+
+describe('handlers', () => {
+    const topic1 = uuid();
+    const topic2 = uuid();
+    const broker = new Broker({
+        namespace: uuid(),
+        config: {
+            brokers: [process.env.KAFKA_BROKER as string],
+        },
+        publications: {
+            'to-topic1': topic1,
+            'to-topic2': topic2,
+        },
+        subscriptions: {
+            'from-all-topics': [
+                topic1,
+                {
+                    topic: topic2,
+                    alias: 'topic2',
+                },
+            ],
+        },
+    });
+
+    afterAll(() => broker.shutdown());
+
+    it('should call handler', async () => {
+        const value1 = uuid();
+        const value2 = uuid();
+        const value3 = uuid();
+        const handler: Handler = jest.fn();
+        const handlerOfTopic1: Handler = jest.fn();
+        const handlerOfTopic2: Handler = jest.fn();
+        const subscription = broker.subscription('from-all-topics');
+        const messages1 = getMessage(subscription, 2);
+
+        await subscription
+            .on('message', handler)
+            .on(`message.${topic1}`, handlerOfTopic1)
+            .on(`message.topic2`, handlerOfTopic2)
+            .run();
+
+        await expect(
+            broker.publish('to-topic1', { value: value1 })
+        ).resolves.toMatchObject([{ topicName: topic1 }]);
+
+        await expect(
+            broker.publish('to-topic2', { value: value2 })
+        ).resolves.toMatchObject([{ topicName: topic2 }]);
+
+        await expect(messages1).resolves.toEqual(
+            expect.arrayContaining([
+                [
+                    value1,
+                    expect.objectContaining({ topic: topic1 }),
+                    expect.any(Function),
+                ],
+                [
+                    value2,
+                    expect.objectContaining({ topic: topic2 }),
+                    expect.any(Function),
+                ],
+            ])
+        );
+
+        expect(handler).toHaveBeenCalledWith(
+            value1,
+            expect.objectContaining({ topic: topic1 }),
+            expect.any(Function)
+        );
+
+        expect(handler).toHaveBeenCalledWith(
+            value2,
+            expect.objectContaining({ topic: topic2 }),
+            expect.any(Function)
+        );
+
+        expect(handlerOfTopic1).toHaveBeenCalledWith(
+            value1,
+            expect.objectContaining({ topic: topic1 }),
+            expect.any(Function)
+        );
+
+        expect(handlerOfTopic2).toHaveBeenCalledWith(
+            value2,
+            expect.objectContaining({ topic: topic2 }),
+            expect.any(Function)
+        );
+
+        subscription.off(`message.${topic1}`, handlerOfTopic1);
+        subscription.off(`message.topic2`, handlerOfTopic2);
+        const messages2 = getMessage(subscription, 2);
+
+        await expect(
+            broker.publish('to-topic1', { value: value3 })
+        ).resolves.toMatchObject([{ topicName: topic1 }]);
+
+        await expect(
+            broker.publish('to-topic2', { value: value3 })
+        ).resolves.toMatchObject([{ topicName: topic2 }]);
+
+        await expect(messages2).resolves.toEqual(
+            expect.arrayContaining([
+                [
+                    value3,
+                    expect.objectContaining({ topic: topic1 }),
+                    expect.any(Function),
+                ],
+                [
+                    value3,
+                    expect.objectContaining({ topic: topic2 }),
+                    expect.any(Function),
+                ],
+            ])
+        );
+
+        expect(handler).toHaveBeenCalledWith(
+            value3,
+            expect.objectContaining({ topic: topic1 }),
+            expect.any(Function)
+        );
+
+        expect(handler).toHaveBeenCalledWith(
+            value3,
+            expect.objectContaining({ topic: topic2 }),
+            expect.any(Function)
+        );
+
+        expect(handlerOfTopic1).not.toHaveBeenCalledWith(
+            value3,
+            expect.objectContaining({ topic: topic1 }),
+            expect.any(Function)
+        );
+
+        expect(handlerOfTopic2).not.toHaveBeenCalledWith(
+            value3,
+            expect.objectContaining({ topic: topic2 }),
+            expect.any(Function)
+        );
+    });
+});

--- a/packages/kafka-broker/src/tests/handlers.test.ts
+++ b/packages/kafka-broker/src/tests/handlers.test.ts
@@ -39,7 +39,6 @@ describe('handlers', () => {
         const value1 = uuid();
         const value2 = uuid();
         const subscription = broker.subscription('from-all-topics');
-
         const messages = getMessage(subscription, 2);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/json+support.test.ts
+++ b/packages/kafka-broker/src/tests/json+support.test.ts
@@ -33,9 +33,7 @@ describe('json+support', () => {
         const id2 = uuid();
         const id3 = uuid();
         const id4 = uuid();
-
         const subscription = broker.subscription('from-topic1');
-
         const messages = getMessage(subscription, 4);
 
         await subscription.run();
@@ -68,9 +66,7 @@ describe('json+support', () => {
 
     it('should force json consume', async () => {
         const id = uuid();
-
         const subscription = broker.subscription('from-topic2');
-
         const message = getMessage(subscription);
 
         await subscription.run();
@@ -94,17 +90,21 @@ describe('json+support', () => {
     });
 
     it('should emit error event', async () => {
-        broker.on('error', () => undefined);
-        const error = new Promise((resolve) => {
-            broker.on('error', resolve);
-        });
+        const brokerError = new Promise((resolve) =>
+            broker.once('error', resolve)
+        );
+        const subscription = broker.subscription('from-topic2');
+        const subscriptionError = new Promise((resolve) =>
+            subscription.once('error', resolve)
+        );
 
-        await broker.subscription('from-topic2').run();
+        await subscription.run();
 
         await expect(
             broker.publish('to-topic2', [{ value: uuid() }])
         ).resolves.toMatchObject([{ topicName: topic2 }]);
 
-        await expect(error).resolves.toThrow(/JSON/);
+        await expect(brokerError).resolves.toThrow(/JSON/);
+        await expect(subscriptionError).resolves.toThrow(/JSON/);
     });
 });

--- a/packages/kafka-broker/src/tests/publish+buffer.test.ts
+++ b/packages/kafka-broker/src/tests/publish+buffer.test.ts
@@ -21,7 +21,6 @@ describe('publish+buffer', () => {
     it('should publish and consume', async () => {
         const value = Buffer.from(uuid());
         const subscription = broker.subscription('from-topic1');
-
         const message = getMessage(subscription);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/publish+config.test.ts
+++ b/packages/kafka-broker/src/tests/publish+config.test.ts
@@ -37,7 +37,6 @@ describe('publish+config', () => {
         ).resolves.toMatchObject([{ topicName: topic }]);
 
         const subscription = broker.subscription('from-topic1');
-
         const messages = getMessage(subscription, 2);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/publish+null.test.ts
+++ b/packages/kafka-broker/src/tests/publish+null.test.ts
@@ -20,7 +20,6 @@ describe('publish+null', () => {
 
     it('should publish and consume', async () => {
         const subscription = broker.subscription('from-topic1');
-
         const message = getMessage(subscription);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/publish+string.test.ts
+++ b/packages/kafka-broker/src/tests/publish+string.test.ts
@@ -21,7 +21,6 @@ describe('publish+string', () => {
     it('should publish and consume', async () => {
         const value = uuid();
         const subscription = broker.subscription('from-topic1');
-
         const message = getMessage(subscription);
 
         await subscription.run();

--- a/packages/kafka-broker/src/tests/schema-registry.test.ts
+++ b/packages/kafka-broker/src/tests/schema-registry.test.ts
@@ -100,7 +100,6 @@ describe('schema registry', () => {
     it('should publish and consume AVRO message', async () => {
         const id = uuid();
         const subscription = broker.subscription('from-topic');
-
         const message = getMessage(subscription);
 
         await subscription.run();
@@ -130,7 +129,6 @@ describe('schema registry', () => {
     it('should publish and consume JSON message', async () => {
         const id = uuid();
         const subscription = broker.subscription('from-topic');
-
         const message = getMessage(subscription);
 
         await subscription.run();
@@ -160,7 +158,6 @@ describe('schema registry', () => {
     it('should publish and consume JSON message from latest version', async () => {
         const id = uuid();
         const subscription = broker.subscription('from-topic');
-
         const message = getMessage(subscription);
 
         await subscription.run();
@@ -190,7 +187,6 @@ describe('schema registry', () => {
     it('should publish and consume JSON message from fixed version', async () => {
         const id = uuid();
         const subscription = broker.subscription('from-topic');
-
         const message = getMessage(subscription);
 
         await subscription.run();

--- a/packages/kafka-broker/src/types.ts
+++ b/packages/kafka-broker/src/types.ts
@@ -132,11 +132,19 @@ export interface BrokerContainerConfig {
 }
 
 export interface SubscriptionInterface {
-    on<V = MessageValue>(event: string, listener: Handler<V>): this;
+    on<V = MessageValue>(
+        event: 'message' | `message.${string}`,
+        listener: Handler<V>
+    ): this;
+    on(event: 'error', listener: (error: Error) => void): this;
 
-    once<V = MessageValue>(event: string, listener: Handler<V>): this;
+    once(event: 'error', listener: (error: Error) => void): this;
 
-    off<V = MessageValue>(event: string, listener: Handler<V>): this;
+    off<V = MessageValue>(
+        event: 'message' | string,
+        listener: Handler<V>
+    ): this;
+    off(event: 'error', listener: (error: Error) => void): this;
 
     run(): Promise<this>;
 }


### PR DESCRIPTION
`Subscription.on()` was based on EventEmitter and was causing messages to be processed too fast or almost all messages to be consumed at once (e.g. if you were consuming a topic from the beginning).
It now waits for every handler to be resolved.